### PR TITLE
feat(commands): add the `ping` command

### DIFF
--- a/mpd_client/src/commands/definitions.rs
+++ b/mpd_client/src/commands/definitions.rs
@@ -64,6 +64,8 @@ macro_rules! single_arg_command {
     };
 }
 
+argless_command!(Ping, "ping", res::Empty);
+
 argless_command!(Next, "next", res::Empty);
 argless_command!(Previous, "previous", res::Empty);
 argless_command!(Stop, "stop", res::Empty);


### PR DESCRIPTION
https://mpd.readthedocs.io/en/latest/protocol.html#command-ping

Adds the `ping` command. This is useful for checking if the connection is still alive, or possibly keeping it open.

I have not mapped the "OK" response, because you can guarantee if the Result is Ok then the ping succeeded.