### PR TITLE
feat(commands): add the `sticker` command set

### DIFF
--- a/mpd_client/src/commands/definitions.rs
+++ b/mpd_client/src/commands/definitions.rs
@@ -1059,7 +1059,7 @@ enum StickerFindOperator {
 pub struct StickerFind {
     uri: String,
     name: String,
-    filter: Option<(StickerFindOperator, String)>
+    filter: Option<(StickerFindOperator, String)>,
 }
 
 impl StickerFind {
@@ -1068,7 +1068,7 @@ impl StickerFind {
         Self {
             uri,
             name,
-            filter: None
+            filter: None,
         }
     }
 
@@ -1091,7 +1091,7 @@ impl StickerFind {
         Self {
             name: self.name,
             uri: self.uri,
-            filter: Some((operator, value))
+            filter: Some((operator, value)),
         }
     }
 }

--- a/mpd_client/src/commands/responses/mod.rs
+++ b/mpd_client/src/commands/responses/mod.rs
@@ -343,21 +343,21 @@ impl Response for Option<AlbumArt> {
 impl sealed::Sealed for StickerGet {}
 impl Response for StickerGet {
     fn from_frame(frame: Frame) -> Result<Self, TypedResponseError> {
-        Ok(StickerGet::from_frame(frame))
+        StickerGet::from_frame(frame)
     }
 }
 
 impl sealed::Sealed for StickerList {}
 impl Response for StickerList {
     fn from_frame(frame: Frame) -> Result<Self, TypedResponseError> {
-        Ok(StickerList::from_frame(frame))
+        StickerList::from_frame(frame)
     }
 }
 
 impl sealed::Sealed for StickerFind {}
 impl Response for StickerFind {
     fn from_frame(frame: Frame) -> Result<Self, TypedResponseError> {
-        Ok(StickerFind::from_frame(frame))
+        StickerFind::from_frame(frame)
     }
 }
 

--- a/mpd_client/src/commands/responses/mod.rs
+++ b/mpd_client/src/commands/responses/mod.rs
@@ -6,6 +6,7 @@ mod util_macros;
 mod list;
 mod playlist;
 mod song;
+mod sticker;
 
 use bytes::Bytes;
 use chrono::ParseError;
@@ -24,6 +25,7 @@ use crate::tag::Tag;
 pub use list::List;
 pub use playlist::Playlist;
 pub use song::{Song, SongInQueue, SongRange};
+pub use sticker::{StickerFind, StickerGet, StickerList};
 
 type KeyValuePair = (Arc<str>, String);
 
@@ -335,6 +337,27 @@ impl Response for Option<AlbumArt> {
             mime: frame.get("type"),
             data,
         }))
+    }
+}
+
+impl sealed::Sealed for StickerGet {}
+impl Response for StickerGet {
+    fn from_frame(frame: Frame) -> Result<Self, TypedResponseError> {
+        Ok(StickerGet::from_frame(frame))
+    }
+}
+
+impl sealed::Sealed for StickerList {}
+impl Response for StickerList {
+    fn from_frame(frame: Frame) -> Result<Self, TypedResponseError> {
+        Ok(StickerList::from_frame(frame))
+    }
+}
+
+impl sealed::Sealed for StickerFind {}
+impl Response for StickerFind {
+    fn from_frame(frame: Frame) -> Result<Self, TypedResponseError> {
+        Ok(StickerFind::from_frame(frame))
     }
 }
 

--- a/mpd_client/src/commands/responses/sticker.rs
+++ b/mpd_client/src/commands/responses/sticker.rs
@@ -45,10 +45,7 @@ impl StickerList {
             .into_iter()
             .map(|(_, value): KeyValuePair| {
                 let split = value.split_once('=').unwrap();
-                (
-                    split.0.to_string(),
-                    split.1.to_string(),
-                )
+                (split.0.to_string(), split.1.to_string())
             })
             .collect();
 

--- a/mpd_client/src/commands/responses/sticker.rs
+++ b/mpd_client/src/commands/responses/sticker.rs
@@ -17,7 +17,7 @@ impl StickerGet {
 
         // server returns the key/value
         // we know the key so just get the value
-        let value = pair.splitn(2, "=").nth(1).unwrap().to_string();
+        let value = pair.split_once('=').unwrap().1.to_string();
 
         Self { value }
     }
@@ -44,10 +44,10 @@ impl StickerList {
         let value = raw
             .into_iter()
             .map(|(_, value): KeyValuePair| {
-                let mut split = value.splitn(2, "=");
+                let split = value.split_once('=').unwrap();
                 (
-                    split.next().unwrap().to_string(),
-                    split.next().unwrap().to_string(),
+                    split.0.to_string(),
+                    split.1.to_string(),
                 )
             })
             .collect();
@@ -74,8 +74,6 @@ pub struct StickerFind {
 
 impl StickerFind {
     pub(crate) fn from_frame(raw: impl IntoIterator<Item = KeyValuePair>) -> Self {
-        // println!("{:?}", raw.into_iter().collect::<Vec<(KeyValuePair)>>());
-
         let mut map = HashMap::new();
 
         let mut file = String::new();
@@ -84,9 +82,8 @@ impl StickerFind {
             |(key, value): KeyValuePair| match key.to_string().as_str() {
                 "file" => file = value,
                 "sticker" => {
-                    let mut split = value.splitn(2, "=");
-                    let value = split.nth(1).unwrap().to_string();
-                    map.insert(file.clone(), value);
+                    let (_, value) = value.split_once('=').unwrap();
+                    map.insert(file.clone(), value.to_string());
                 }
                 _ => panic!("Invalid response received from server"),
             },

--- a/mpd_client/src/commands/responses/sticker.rs
+++ b/mpd_client/src/commands/responses/sticker.rs
@@ -1,0 +1,97 @@
+use super::KeyValuePair;
+use std::collections::HashMap;
+
+/// Response to the [`sticker get`] command.
+///
+/// [`sticker get`]: crate::commands::definitions::StickerGet
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct StickerGet {
+    /// The sticker value
+    pub value: String,
+}
+
+impl StickerGet {
+    pub(crate) fn from_frame(raw: impl IntoIterator<Item = KeyValuePair>) -> Self {
+        let pair: String = raw.into_iter().map(|(_, value)| value).next().unwrap();
+
+        // server returns the key/value
+        // we know the key so just get the value
+        let value = pair.splitn(2, "=").nth(1).unwrap().to_string();
+
+        Self { value }
+    }
+}
+
+impl From<StickerGet> for String {
+    fn from(sticker_get: StickerGet) -> Self {
+        sticker_get.value
+    }
+}
+
+/// Response to the [`sticker list`] command.
+///
+/// [`sticker list`]: crate::commands::definitions::StickerList
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct StickerList {
+    /// A map of sticker names to their values
+    pub value: HashMap<String, String>,
+}
+
+impl StickerList {
+    pub(crate) fn from_frame(raw: impl IntoIterator<Item = KeyValuePair>) -> Self {
+        let value = raw
+            .into_iter()
+            .map(|(_, value): KeyValuePair| {
+                let mut split = value.splitn(2, "=");
+                (
+                    split.next().unwrap().to_string(),
+                    split.next().unwrap().to_string(),
+                )
+            })
+            .collect();
+
+        Self { value }
+    }
+}
+
+impl From<StickerList> for HashMap<String, String> {
+    fn from(sticker_list: StickerList) -> Self {
+        sticker_list.value
+    }
+}
+
+/// Response to the [`sticker find`] command.
+///
+/// [`sticker find`]: crate::commands::definitions::StickerFind
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct StickerFind {
+    /// A map of songs to their sticker values
+    pub value: HashMap<String, String>,
+}
+
+impl StickerFind {
+    pub(crate) fn from_frame(raw: impl IntoIterator<Item = KeyValuePair>) -> Self {
+        // println!("{:?}", raw.into_iter().collect::<Vec<(KeyValuePair)>>());
+
+        let mut map = HashMap::new();
+
+        let mut file = String::new();
+
+        raw.into_iter().for_each(
+            |(key, value): KeyValuePair| match key.to_string().as_str() {
+                "file" => file = value,
+                "sticker" => {
+                    let mut split = value.splitn(2, "=");
+                    let value = split.nth(1).unwrap().to_string();
+                    map.insert(file.clone(), value);
+                }
+                _ => panic!("Invalid response received from server"),
+            },
+        );
+
+        Self { value: map }
+    }
+}


### PR DESCRIPTION
https://mpd.readthedocs.io/en/latest/protocol.html#stickers

Adds each of the `sticker` commands for interacting with the sticker database (resolves #13).

There's some room for improvement in the code (esp. regarding the format of the responses), but everything is *working* so now seems like a good time to submit for review :)

Minimal usage example of each command:
```rust
use mpd_client::{commands, Client};
use tokio::net::TcpStream;

#[tokio::main]
async fn main() {
    let connection = TcpStream::connect("localhost:6600").await.unwrap();
    let (client, _) = Client::connect(connection).await.unwrap();

    set_sticker(&client).await;
    get_sticker(&client).await;
    list_stickers(&client).await;
    find_stickers(&client).await;
    find_stickers_where(&client).await;
    delete_sticker(&client).await;
}

async fn get_sticker(client: &Client) {
    let value = client
        .command(commands::StickerGet::new(
            "path/to/some/song.flac".to_string(),
            "live".to_string(),
        ))
        .await;
    println!("{:?}", value);
}

async fn set_sticker(client: &Client) {
    client
        .command(commands::StickerSet::new(
            "path/to/some/song.flac".to_string(),
            "live".to_string(),
            "true".to_string(),
        ))
        .await
        .unwrap();
}

async fn delete_sticker(client: &Client) {
    client
        .command(commands::StickerDelete::new(
            "path/to/some/song.flac".to_string(),
            "live".to_string(),
        ))
        .await
        .unwrap();
}

async fn list_stickers(client: &Client) {
    let stickers = client
        .command(commands::StickerList::new(
            "path/to/some/song.flac".to_string(),
        ))
        .await;

    println!("{:?}", stickers);
}

async fn find_stickers(client: &Client) {
    let stickers = client
        .command(commands::StickerFind::new(
            "Path/to".to_string(),
            "live".to_string()
        ))
        .await;

    println!("{:?}", stickers);
}

async fn find_stickers_where(client: &Client) {
    let stickers = client
        .command(commands::StickerFind::new(
            "path/to".to_string(),
            "live".to_string()
        ).where_eq("true".to_string()))
        .await;

    println!("{:?}", stickers);
}
```

Let me know what you think; more than happy to change some bits around.